### PR TITLE
User should send a signed zoomid when deleting account

### DIFF
--- a/src/server/storage/__tests__/storageAPI.js
+++ b/src/server/storage/__tests__/storageAPI.js
@@ -40,4 +40,38 @@ describe('storageAPI', () => {
       .send({ user })
     expect(res).toMatchObject({ status: 400 })
   })
+  
+  test('/user/delete with zoomId and bad signature', async () => {
+    const token = await getToken(server)
+    let res = await request(server)
+      .post('/user/delete')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        zoomId: "DEc4f150b719957a2dD434C48Dff9Bc57466e764",
+        zoomSignature: "Bad signature"
+      })
+    expect(res).toMatchObject({ status: 400 })
+  })
+  
+  test('/user/delete without zoomId ', async () => {
+    const token = await getToken(server)
+    let res = await request(server)
+      .post('/user/delete')
+      .set('Authorization', `Bearer ${token}`)
+      .send()
+    expect(res).toMatchObject({ status: 200 })
+  })
+  
+  test('/user/delete with zoomId and good signature', async () => {
+    const token = await getToken(server)
+    let res = await request(server)
+      .post('/user/delete')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        zoomId: "DEc4f150b719957a2dD434C48Dff9Bc57466e764",
+        zoomSignature: "0xda0c23e71a589adfb4f29b021549371f44de105678284e4d9acecb8b670a35c63bd1e200ae9293dcca0064ae87438094df7e7db3268c47e638cdffdfe8c386a11c"
+      })
+    expect(res).toMatchObject({ status: 200 })
+  })
+  
 })

--- a/src/server/storage/storageAPI.js
+++ b/src/server/storage/storageAPI.js
@@ -129,28 +129,34 @@ const setup = (app: Router, storage: StorageAPI) => {
     passport.authenticate('jwt', { session: false }),
     wrapAsync(async (req, res, next) => {
       const { user, log, body } = req
+      const {zoomSignature, zoomId} = body
       log.info('delete user', { user })
-
-      const recovered = recoverPublickey(body.zoomSignature, body.zoomId, '').replace('0x', '')
-      if (recovered === body.zoomId.toLowerCase()) {
-        const results = await Promise.all([
-          (user.identifier ? storage.deleteUser(user) : Promise.reject())
-            .then(r => ({ mongodb: 'ok' }))
-            .catch(e => ({ mongodb: 'failed' })),
-          zoomHelper
-            .delete(body.zoomId)
-            .then(r => ({ zoom: 'ok' }))
-            .catch(e => ({ zoom: 'failed' })),
-          Mautic.deleteContact(user)
-            .then(r => ({ mautic: 'ok' }))
-            .catch(e => ({ mautic: 'failed' }))
-        ])
-        log.info('delete user results', { results })
-        res.json({ ok: 1, results })
-      } else {
-        log.error('/user/delete', 'SigUtil unable to recover the message signer')
-        throw new Error('Unable to verify credentials')
+      
+      if (zoomId && zoomSignature) {
+        
+        const recovered = recoverPublickey(zoomSignature, zoomId, '').replace('0x', '')
+        
+        if (recovered === body.zoomId.toLowerCase()) {
+          await zoomHelper.delete(zoomId)
+          log.info('zoom delete', { zoomId })
+        } else {
+          log.error('/user/delete', 'SigUtil unable to recover the message signer')
+          throw new Error('Unable to verify credentials')
+        }
+        
       }
+      
+      const results = await Promise.all([
+        (user.identifier ? storage.deleteUser(user) : Promise.reject())
+          .then(r => ({ mongodb: 'ok' }))
+          .catch(e => ({ mongodb: 'failed' })),
+        Mautic.deleteContact(user)
+          .then(r => ({ mautic: 'ok' }))
+          .catch(e => ({ mautic: 'failed' }))
+      ])
+      
+      log.info('delete user results', { results })
+      res.json({ ok: 1, results })
     })
   )
 


### PR DESCRIPTION
[User should send a signed zoomid when deleting account](https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/495)

User deletion method expected signature for preliminary verification

Add unit tests and if zoom id is not supplied the delete should not fail, it should just skip deleting the zoom record