### PR TITLE
Add network id to mongo db when lock and check wallet address

### DIFF
--- a/src/server/db/mongo/models/wallet-nonce.js
+++ b/src/server/db/mongo/models/wallet-nonce.js
@@ -6,6 +6,7 @@ export const WalletNonceSchema = new mongoose.Schema({
     type: String,
     index: { unique: true }
   },
+  networkId: String,
   nonce: {
     type: Number,
     default: 0

--- a/src/server/utils/eth.js
+++ b/src/server/utils/eth.js
@@ -8,9 +8,7 @@ export const recoverPublickey = (signature, msg, nonce) => {
   )
 
   const publicKey = ethUtil.ecrecover(messageHash, sig.v, sig.r, sig.s)
-  const recovered = ethUtil.bufferToHex(ethUtil.pubToAddress(publicKey))
-
-  return recovered
+  return ethUtil.bufferToHex(ethUtil.pubToAddress(publicKey))
 }
 
 /**
@@ -21,6 +19,8 @@ export const recoverPublickey = (signature, msg, nonce) => {
 export const isNonceError = e => {
   const message = (e && e.message && String(e.message)) || ''
   return !!(
-    ~message.indexOf('Transaction nonce is too low') || ~message.indexOf("the tx doesn't have the correct nonce")
+    ~message.indexOf('Transaction nonce is too low') ||
+    ~message.indexOf("the tx doesn't have the correct nonce") ||
+    ~message.indexOf('transaction with same nonce in the queue')
   )
 }

--- a/src/server/utils/tx-manager/queueMongo.js
+++ b/src/server/utils/tx-manager/queueMongo.js
@@ -79,7 +79,8 @@ export default class queueMongo {
       if (!wallet) {
         await this.model.create({
           address,
-          nonce: netNonce
+          nonce: netNonce,
+          networkId: this.networkId
         })
       }
     } catch (e) {
@@ -99,7 +100,8 @@ export default class queueMongo {
     await this.model.findOneAndUpdate(
       { address },
       {
-        isLock: false
+        isLock: false,
+        networkId: this.networkId
       },
       { returnNewDocument: true }
     )
@@ -119,7 +121,8 @@ export default class queueMongo {
         { address },
         {
           isLock: false,
-          nonce: nextNonce
+          nonce: nextNonce,
+          networkId: this.networkId
         },
         { returnNewDocument: true }
       )

--- a/src/server/utils/tx-manager/queueMongo.js
+++ b/src/server/utils/tx-manager/queueMongo.js
@@ -1,10 +1,12 @@
 import WalletNonce from '../../db/mongo/models/wallet-nonce'
 import logger from '../../../imports/pino-logger'
+import conf from '../../server.config'
 
 const log = logger.child({ from: 'queueMongo' })
 const MAX_LOCK_TIME = 30 // seconds
 export default class queueMongo {
   constructor() {
+    this.networkId = conf.ethereum.network_id
     this.model = WalletNonce
     this.queue = []
     this.nonce = null
@@ -41,11 +43,12 @@ export default class queueMongo {
             { isLock: false },
             {
               lockedAt: { $lte: +new Date() - MAX_LOCK_TIME * 1000 },
-              isLock: true
+              isLock: true,
+              networkId: this.networkId
             }
           ]
         },
-        { isLock: true, lockedAt: +new Date() },
+        { isLock: true, lockedAt: +new Date(), networkId: this.networkId },
         { returnNewDocument: true }
       )
       if (this.reRunQueue) {


### PR DESCRIPTION

This PR closes https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/667


* Add current networkId to mongo queue
So now mongo model looks like this
![image](https://user-images.githubusercontent.com/36693645/65681894-86883100-e062-11e9-843a-ac18ab15fdf6.png)
