### PR TITLE
(bug)Can't reuse email/mobile if registration didnt complete

### DIFF
--- a/src/server/storage/storageAPI.js
+++ b/src/server/storage/storageAPI.js
@@ -39,11 +39,13 @@ const setup = (app: Router, storage: StorageAPI) => {
       )
         throw new Error('User email or mobile not verified!')
 
-      const bodyUser = body.user
+      const { email, mobile, ...bodyUser } = body.user
 
       const user: UserRecord = defaults(bodyUser, {
         identifier: userRecord.loggedInAs,
-        createdDate: new Date().toString()
+        createdDate: new Date().toString(),
+        email: userRecord.otp.email,
+        mobile: userRecord.otp.mobile
       })
 
       if (conf.disableFaceVerification) {

--- a/src/server/storage/storageAPI.js
+++ b/src/server/storage/storageAPI.js
@@ -39,7 +39,8 @@ const setup = (app: Router, storage: StorageAPI) => {
       )
         throw new Error('User email or mobile not verified!')
 
-      const { email, mobile, ...bodyUser } = body.user
+      const bodyUser = body.user
+
       const user: UserRecord = defaults(bodyUser, {
         identifier: userRecord.loggedInAs,
         createdDate: new Date().toString()

--- a/src/server/verification/verificationAPI.js
+++ b/src/server/verification/verificationAPI.js
@@ -188,7 +188,7 @@ const setup = (app: Router, verifier: VerificationAPI, storage: StorageAPI) => {
 
         if (verified === false) return
 
-        await storage.updateUser({ identifier: user.loggedInAs, smsValidated: true, mobile: savedMobile })
+        await storage.updateUser({ identifier: user.loggedInAs, smsValidated: true })
       }
 
       const signedMobile = await GunDBPublic.signClaim(user.profilePubkey, { hasMobile: savedMobile })
@@ -342,7 +342,7 @@ const setup = (app: Router, verifier: VerificationAPI, storage: StorageAPI) => {
         await verifier.verifyEmail({ identifier: user.loggedInAs }, verificationData)
 
         // if verification succeeds, then set the flag `isEmailConfirmed` to true in the user's record
-        await storage.updateUser({ identifier: user.loggedInAs, isEmailConfirmed: true, email: savedEmail })
+        await storage.updateUser({ identifier: user.loggedInAs, isEmailConfirmed: true })
       }
       const signedEmail = await GunDBPublic.signClaim(req.user.profilePubkey, { hasEmail: savedEmail })
 


### PR DESCRIPTION
# Description

I removed the preliminary storage of the email and phone in the database. This data is saved when a user is added at (/user/add)

Fixes # https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/goodserver/103

# How Has This Been Tested?

If user stops registration in the middle and restarts it after validating his mobile number
he will get an error that mobile is already in

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
