### PR TITLE
(Bug) #799 bonus event should be from good dollar and not unknown

### DIFF
--- a/src/server/verification/verificationAPI.js
+++ b/src/server/verification/verificationAPI.js
@@ -554,11 +554,8 @@ const setup = (app: Router, verifier: VerificationAPI, storage: StorageAPI) => {
           log.info('Bonus redeem - receipt received', r)
 
           await W3Helper.informW3ThatBonusCharged(toRedeem, wallet_token)
+
           release()
-          return res.status(200).json({
-            bonusAmount: toRedeem,
-            hash: r.transactionHash
-          })
         },
         onError: e => {
           log.error('Bonuses charge failed', e.message, e, currentUser)
@@ -570,6 +567,10 @@ const setup = (app: Router, verifier: VerificationAPI, storage: StorageAPI) => {
             message: 'Failed to redeem bonuses for user'
           })
         }
+      })
+
+      return res.status(200).json({
+        ok: 1
       })
     })
   )


### PR DESCRIPTION
# Description

Send a response to Dapp after start redeems bonuses - don't wait for transaction hash.

About https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/799

# How Has This Been Tested?

Described in GoodDapp PR.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes

The link to GoodDapp PR - https://github.com/GoodDollar/GoodDAPP/pull/886