### PR TITLE
(Bug) #133 user not able to create account after failure

### DIFF
--- a/src/server/storage/addUserSteps.js
+++ b/src/server/storage/addUserSteps.js
@@ -44,7 +44,7 @@ const updateMauticRecord = async (userRecord: UserRecord) => {
 }
 
 const updateW3Record = async (user: any) => {
-  if (conf.isEtoro === false) {
+  if (conf.env !== 'test' && conf.isEtoro === false) {
     return
   }
   let userDB = await UserDBPrivate.getUser(user.identifier)
@@ -66,7 +66,7 @@ const updateW3Record = async (user: any) => {
 }
 
 const updateMarketToken = async (user: any) => {
-  if (conf.isEtoro === false) {
+  if (conf.env !== 'test' && conf.isEtoro === false) {
     return
   }
 

--- a/src/server/storage/storageAPI.js
+++ b/src/server/storage/storageAPI.js
@@ -73,7 +73,7 @@ const setup = (app: Router, storage: StorageAPI) => {
 
       logger.debug('added new user:', { user, ok })
 
-      await UserDBPrivate.updateUser({
+      await storage.updateUser({
         identifier: userRecord.loggedInAs,
         createdDate: new Date().toString()
       })

--- a/src/server/storage/storageAPI.js
+++ b/src/server/storage/storageAPI.js
@@ -47,7 +47,6 @@ const setup = (app: Router, storage: StorageAPI) => {
 
       const user: UserRecord = defaults(bodyUser, {
         identifier: userRecord.loggedInAs,
-        createdDate: new Date().toString(),
         email: get(userRecord, 'otp.email', email), //for development/test use email from body
         mobile: get(userRecord, 'otp.mobile', mobile), //for development/test use mobile from body
         isCompleted: {
@@ -73,6 +72,11 @@ const setup = (app: Router, storage: StorageAPI) => {
       let ok = await addUserSteps.topUserWallet(userRecord)
 
       logger.debug('added new user:', { user, ok })
+
+      await UserDBPrivate.updateUser({
+        identifier: userRecord.loggedInAs,
+        createdDate: new Date().toString()
+      })
 
       res.json({
         ...ok,


### PR DESCRIPTION
# Description

move the update createdDate field to the end of /user/add fn handler.

About #133 

# How Has This Been Tested?

You need to simulate some error on backend after userRecord already updated.
Try to create a user (click on lets start).
You should be registered without 'the same creds used' error.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
