### PR TITLE
(Bug) #1085 User who claimed G$ on Hanukkah 2nd day gets 0 G$ bonuses

### DIFF
--- a/src/server/verification/verificationAPI.js
+++ b/src/server/verification/verificationAPI.js
@@ -434,7 +434,7 @@ const setup = (app: Router, verifier: VerificationAPI, storage: StorageAPI) => {
         })
       }
 
-      const currentDayNumber = startHanuka.diff(now, 'days') + 1
+      const currentDayNumber = now.diff(startHanuka, 'days') + 1
       const dayField = `day${currentDayNumber}`
 
       if (user.hanukaBonus && user.hanukaBonus[dayField]) {


### PR DESCRIPTION
# Description

Fix the calculation for a current hanuka bonus day.

About #https://app.zenhub.com/workspaces/gooddollar-5d50833888a83c6880d3e345/issues/gooddollar/gooddapp/1085

# How Has This Been Tested?

The bonus amount should come the same as the number of Hanuka bonus day.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
