### PR TITLE
(Chore) Search failing because of liveness should be treated like liveness failure

### DIFF
--- a/src/server/verification/api/__tests__/__util__/index.js
+++ b/src/server/verification/api/__tests__/__util__/index.js
@@ -1,6 +1,7 @@
 export default zoomServiceMock => {
   const serviceErrorMessage = 'Request failed with status code 500'
   const failedEnrollmentMessage = 'The FaceMap was not enrolled because Liveness could not be determined.'
+  const failedLivenessMessage = '3D FaceMaps that are used with Search APIs must have had Liveness Proven.'
   const enrollmentDisposedMessage = 'The entry in the database for this enrollmentIdentifier was successfully deleted'
   const enrollmentFoundMessage = 'A FaceMap was found for that enrollmentIdentifier.'
   const enrollmentNotFoundMessage = 'No entry found in the database for this enrollmentIdentifier.'
@@ -62,6 +63,21 @@ export default zoomServiceMock => {
             auditTrailImage: 'data:image/png:FaKEimagE=='
           }
         ]
+      }
+    })
+
+  const mockLivenessError = () =>
+    zoomServiceMock.onPost('/search').reply(400, {
+      meta: {
+        code: 400,
+        ok: false,
+        m: { zb: 2256, st: 1594565626.252231, bt: null, bp: null, zw: 2545, zp: 2528 },
+        subCode: 'unableToProcess',
+        mode: 'dev',
+        message: '3D FaceMaps that are used with Search APIs must have had Liveness Proven.'
+      },
+      data: {
+        isLive: false
       }
     })
 
@@ -175,7 +191,9 @@ export default zoomServiceMock => {
 
     mockSuccessEnrollment,
     mockFailedEnrollment,
+    mockLivenessError,
     failedEnrollmentMessage,
+    failedLivenessMessage,
 
     mockEnrollmentFound,
     mockEnrollmentNotFound,

--- a/src/server/verification/processor/provider/__tests__/ZoomProvider.js
+++ b/src/server/verification/processor/provider/__tests__/ZoomProvider.js
@@ -141,6 +141,20 @@ describe('ZoomProvider', () => {
     expect(onEnrollmentProcessing).toHaveBeenNthCalledWith(2, { isEnrolled: false, isLive: false })
   })
 
+  test('enroll() throws 3D Facemap liveness error', async () => {
+    helper.mockEmptyResultsFaceSearch()
+    helper.mockLivenessError()
+
+    const onEnrollmentProcessing = jest.fn()
+    const wrappedResponse = expect(ZoomProvider.enroll(enrollmentIdentifier, payload, onEnrollmentProcessing)).rejects
+
+    await wrappedResponse.toThrow(helper.failedLivenessMessage)
+    await wrappedResponse.toHaveProperty('response')
+    await wrappedResponse.toHaveProperty('response.isLive', false)
+
+    expect(onEnrollmentProcessing).toHaveBeenNthCalledWith(1, { isLive: false })
+  })
+
   test('enroll() throws on any Zoom service error and terminates without returning any response or calling callback', async () => {
     zoomServiceMock
       .onPost('/search')


### PR DESCRIPTION

# Description

- add catch '3D FaceMaps that are used with Search APIs must have had Liveness Proven.' as liveness isuue

About https://github.com/GoodDollar/GoodDAPP/issues/2148

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
