### PR TITLE
Fixes of log.errors and tests

### DIFF
--- a/src/imports/logger/ErrorsTransport.js
+++ b/src/imports/logger/ErrorsTransport.js
@@ -35,7 +35,10 @@ export default class ErrorsTransport extends Transport {
 
   log(context) {
     const { message: generalMessage, userId, ...data } = context
-    const [errorMessage, errorObj, extra = {}] = context[SPLAT]
+
+    // context[SPLAT] could be undefined in case if just one argument passed to the error log
+    // i.e log.error('some error message')
+    const [errorMessage, errorObj, extra = {}] = context[SPLAT] || []
     const dataToPassIntoLog = { generalMessage, errorMessage, errorObj, ...extra, ...data }
     let errorToPassIntoLog = errorObj
 

--- a/src/server/blockchain/AdminWallet.js
+++ b/src/server/blockchain/AdminWallet.js
@@ -170,7 +170,7 @@ export class Wallet {
     const adminWalletContractBalance = await this.web3.eth.getBalance(adminWalletAddress)
     log.info(`AdminWallet contract balance`, { adminWalletContractBalance, adminWalletAddress })
     if (adminWalletContractBalance < adminMinBalance * this.addresses.length) {
-      log.error('AdminWallet contract low funds', {})
+      log.error('AdminWallet contract low funds')
       if (conf.env !== 'test' && conf.env !== 'development') process.exit(-1)
     }
 
@@ -683,7 +683,7 @@ export class Wallet {
         (await tx
           .estimateGas()
           .then(gas => gas + 200000) //buffer for proxy contract, reimburseGas?, and low gas unexpected failures
-          .catch(e => log.error('Failed to estimate gas for tx', { errMessage: e.message, e }))) ||
+          .catch(e => log.error('Failed to estimate gas for tx', e.message, e))) ||
         defaultGas
 
       //adminwallet contract might give wrong gas estimates, so if its more than block gas limit reduce it to default
@@ -715,7 +715,7 @@ export class Wallet {
           })
           .on('confirmation', c => onConfirmation && onConfirmation(c))
           .on('error', async e => {
-            log.error('sendTransaction error:', { error: e.message, e, from: address, uuid })
+            log.error('sendTransaction error:', e.message, e, { from: address, uuid })
             if (isNonceError(e)) {
               let netNonce = parseInt(await this.mainnetWeb3.eth.getTransactionCount(address))
               log.warn('sendTransaciton nonce failure retry', {

--- a/src/server/blockchain/stakingModelTasks.js
+++ b/src/server/blockchain/stakingModelTasks.js
@@ -71,7 +71,7 @@ export class StakingModelManager {
       //top ropsten wallet
       if (moment().diff(this.lastRopstenTopping, 'days') > 0) {
         fetch('https://faucet.metamask.io', { method: 'POST', body: AdminWallet.mainnetAddresses[0] }).catch(e => {
-          this.log.error('failed calling ropsten faucet', e)
+          this.log.error('failed calling ropsten faucet', e.message, e)
         })
         this.lastRopstenTopping = moment()
       }
@@ -156,7 +156,7 @@ export class StakingModelManager {
       const cronTime = await this.getNextCollectionTime()
       //make sure atleast one hour passes in case of an error
       if (cronTime.isBefore(moment().add(1, 'hour'))) cronTime.add(1, 'hour')
-      this.log.error('collecting interest failed.', { e, errMsg: e.message, cronTime })
+      this.log.error('collecting interest failed.', e.message, e, { cronTime })
       return { result: false, cronTime }
     }
   }
@@ -321,7 +321,7 @@ class FishingManager {
         unfished = unfished.concat(tofish.slice(totalFished))
         fishers.push(fisherAccount)
       } catch (e) {
-        this.log.error('Failed fishing chunk', { tofish, error: e.message, e })
+        this.log.error('Failed fishing chunk', e.message, e, { tofish })
       }
     }
     if (unfished.length > 0) {
@@ -338,7 +338,7 @@ class FishingManager {
       const cronTime = await this.getNextDay()
       return { result: true, cronTime, fishers }
     } catch (e) {
-      this.log.error('fishing task failed:', { e, errMsg: e.message })
+      this.log.error('fishing task failed:', e.message, e)
       const cronTime = await this.getNextDay()
       if (cronTime.isBefore(moment().add(1, 'hour'))) cronTime.add(1, 'hour')
       return { result: true, cronTime }

--- a/src/server/db/mongo/user-privat-provider.js
+++ b/src/server/db/mongo/user-privat-provider.js
@@ -312,9 +312,8 @@ class UserPrivate {
       )
     } catch (exception) {
       const { message: errMessage } = exception
-      const logPayload = { e: exception, errMessage, tasksIdentifiers }
 
-      logger.error("Couldn't unlock and update delayed tasks", logPayload)
+      logger.error("Couldn't unlock and update delayed tasks", errMessage, exception, { tasksIdentifiers })
       throw exception
     }
   }

--- a/src/server/verification/__tests__/verificationAPI.js
+++ b/src/server/verification/__tests__/verificationAPI.js
@@ -261,7 +261,9 @@ describe('verificationAPI', () => {
           error: helper.duplicateFoundMessage,
           enrollmentResult: {
             isVerified: false,
-            isDuplicate: true
+            isDuplicate: true,
+            code: 200,
+            message: 'The search request was processed successfully.'
           }
         })
 

--- a/src/server/verification/processor/EnrollmentSession.js
+++ b/src/server/verification/processor/EnrollmentSession.js
@@ -55,7 +55,7 @@ export default class EnrollmentSession {
         result.enrollmentResult = response
       }
 
-      log.error('Enrollment session failed with exception:', { result, exception })
+      log.error('Enrollment session failed with exception:', message, exception, { result })
 
       this.onEnrollmentFailed(exception)
     } finally {

--- a/src/server/verification/verificationAPI.js
+++ b/src/server/verification/verificationAPI.js
@@ -101,7 +101,7 @@ const setup = (app: Router, verifier: VerificationAPI, gunPublic: StorageAPI, st
         res.json({ success: true, sessionToken })
       } catch (exception) {
         const { message } = exception
-        log.error('generating enrollment session token failed:', { message, exception, user })
+        log.error('generating enrollment session token failed:', message, exception, { user })
         res.status(400).json({ success: false, error: message })
       }
     })


### PR DESCRIPTION
# Description

- Fix test - VerificationAPI PUT /verify/face/:enrollmentIdentifier returns 200 and success: false when verification wasn't successful.
- check and fix log.error arguments format and order across the project.
- Add default valud for context[SPLAT] as it cpuld be undefined in case log.error called with just one argument (i.e log.error('some error message'))

