### PR TITLE
add:  use wallet private key for gun SEA pair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2118,6 +2118,30 @@
         }
       }
     },
+    "@gooddollar/gun-pk-auth": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@gooddollar/gun-pk-auth/-/gun-pk-auth-1.0.2.tgz",
+      "integrity": "sha512-urh6Orfo4yEM3E1X3l8a+Op1S1cQUK4m/BJvm2FnjVP9+Pqa8YJIsPcY91UAT5ArH6RmBdaTqDOSZhpA68oK7g==",
+      "requires": {
+        "elliptic": "^6.5.2"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/polyfill": "^7.4.4",
     "@gooddollar/goodcontracts": "^2.0.0",
     "@gooddollar/gun": "^0.2020.719",
+    "@gooddollar/gun-pk-auth": "^1.0.2",
     "@sendgrid/mail": "^6.4.0",
     "@sentry/integrations": "^5.19.2",
     "@sentry/node": "^5.19.0",

--- a/src/server/server-dev.js
+++ b/src/server/server-dev.js
@@ -47,7 +47,7 @@ const server = app.listen(PORT, () => {
   console.log('Press Ctrl+C to quit.')
 })
 AdminWallet.ready.then(_ => {
-  const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey
+  const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey.slice(2)
   GunDBPublic.init(server, pkey, 'publicdb', conf.gunPublicS3).catch(e => {
     console.error(e)
     process.exit(-1)

--- a/src/server/server-dev.js
+++ b/src/server/server-dev.js
@@ -5,6 +5,7 @@ import config from '../../webpack.dev.config'
 import conf from './server.config'
 import { GunDBPublic } from './gun/gun-middleware'
 import startApp from './app'
+import AdminWallet from './blockchain/AdminWallet'
 
 process.on('uncaughtException', (err, origin) => {
   console.log(`Caught exception: ${err}\nException origin: ${origin}`)
@@ -45,7 +46,10 @@ const server = app.listen(PORT, () => {
   console.log(`App listening to ${PORT}....`)
   console.log('Press Ctrl+C to quit.')
 })
-GunDBPublic.init(server, conf.gundbPassword, 'publicdb', conf.gunPublicS3).catch(e => {
-  console.error(e)
-  process.exit(-1)
+AdminWallet.ready.then(_ => {
+  const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey
+  GunDBPublic.init(server, pkey, 'publicdb', conf.gunPublicS3).catch(e => {
+    console.error(e)
+    process.exit(-1)
+  })
 })

--- a/src/server/server-dev.js
+++ b/src/server/server-dev.js
@@ -46,10 +46,3 @@ const server = app.listen(PORT, () => {
   console.log(`App listening to ${PORT}....`)
   console.log('Press Ctrl+C to quit.')
 })
-AdminWallet.ready.then(_ => {
-  const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey.slice(2)
-  GunDBPublic.init(server, pkey, 'publicdb', conf.gunPublicS3).catch(e => {
-    console.error(e)
-    process.exit(-1)
-  })
-})

--- a/src/server/server-middlewares.js
+++ b/src/server/server-middlewares.js
@@ -18,7 +18,24 @@ import VerificationAPI from './verification/verification'
 import createDisposeEnrollmentsTask from './verification/cron/DisposeEnrollmentsTask'
 import addClaimQueueMiddlewares from './claimQueue/claimQueueAPI'
 import { fishInactiveTask, collectFundsTask } from './blockchain/stakingModelTasks'
+import conf from './server.config'
+import AdminWallet from './blockchain/AdminWallet'
+import requestTimeout from './utils/timeout'
+
 export default (app: Router, env: any) => {
+  Promise.race([
+    requestTimeout(30000, 'gun not initialized'),
+    AdminWallet.ready.then(_ => {
+      const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey.slice(2)
+      //we no longer use backend also as gundb  server, otherwise this needs to be moved back
+      //to server-prod.js so we can pass the express server instance instead of null
+      GunDBPublic.init(null, pkey, 'publicdb')
+    })
+  ]).catch(e => {
+    console.log('gun failed... quiting', e)
+    process.exit(-1)
+  })
+
   // parse application/x-www-form-urlencoded
   // for easier testing with Postman or plain HTML forms
   app.use(express.json({ limit: '100mb', extended: true }))

--- a/src/server/server-prod.js
+++ b/src/server/server-prod.js
@@ -4,6 +4,7 @@ import conf from './server.config'
 import { GunDBPublic } from './gun/gun-middleware'
 import requestTimeout from './utils/timeout'
 import startApp from './app'
+import AdminWallet from './blockchain/AdminWallet'
 
 export default function start(workerId) {
   global.workerId = workerId
@@ -36,7 +37,10 @@ export default function start(workerId) {
 
   Promise.race([
     requestTimeout(30000, 'gun not initialized'),
-    GunDBPublic.init(server, conf.gundbPassword, `publicdb${workerId}`, conf.gunPublicS3)
+    AdminWallet.ready.then(_ => {
+      const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey
+      GunDBPublic.init(server, pkey, 'publicdb', conf.gunPublicS3)
+    })
   ]).catch(e => {
     console.log('gun failed... quiting', e)
     process.exit(-1)

--- a/src/server/server-prod.js
+++ b/src/server/server-prod.js
@@ -1,10 +1,6 @@
 import path from 'path'
 import express from 'express'
-import conf from './server.config'
-import { GunDBPublic } from './gun/gun-middleware'
-import requestTimeout from './utils/timeout'
 import startApp from './app'
-import AdminWallet from './blockchain/AdminWallet'
 
 export default function start(workerId) {
   global.workerId = workerId
@@ -33,16 +29,5 @@ export default function start(workerId) {
   const server = app.listen(PORT, () => {
     console.log(`App listening to ${PORT}....`)
     console.log('Press Ctrl+C to quit.')
-  })
-
-  Promise.race([
-    requestTimeout(30000, 'gun not initialized'),
-    AdminWallet.ready.then(_ => {
-      const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey.slice(2)
-      GunDBPublic.init(server, pkey, 'publicdb', conf.gunPublicS3)
-    })
-  ]).catch(e => {
-    console.log('gun failed... quiting', e)
-    process.exit(-1)
   })
 }

--- a/src/server/server-prod.js
+++ b/src/server/server-prod.js
@@ -38,7 +38,7 @@ export default function start(workerId) {
   Promise.race([
     requestTimeout(30000, 'gun not initialized'),
     AdminWallet.ready.then(_ => {
-      const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey
+      const pkey = AdminWallet.wallets[AdminWallet.addresses[0]].privateKey.slice(2)
       GunDBPublic.init(server, pkey, 'publicdb', conf.gunPublicS3)
     })
   ]).catch(e => {


### PR DESCRIPTION
# Description

- stop using user/password for gun login as it is unreliable
- use package gun-pk-auth which generates SEA keys based on a SEED
- use AdminWallet first wallet private key as SEED

**notice
this will cause old trusted  indexes to stop working, so feed might display empty data for accounts created   before this update**