### PR TITLE
(Bug) Adapt ZoOm API client to non-testing mode

### DIFF
--- a/src/server/verification/api/__tests__/ZoomAPI.js
+++ b/src/server/verification/api/__tests__/ZoomAPI.js
@@ -124,8 +124,7 @@ describe('ZoomAPI', () => {
         ok: false,
         code: 400,
         mode: 'dev',
-        message: faceSearchServiceError,
-        subCode: 'invalidSessionId'
+        message: faceSearchServiceError
       }
     })
 
@@ -172,8 +171,7 @@ describe('ZoomAPI', () => {
         ok: false,
         code: 400,
         mode: 'dev',
-        message: enrollmentServiceError,
-        subCode: 'missingParameter'
+        message: enrollmentServiceError
       }
     })
 

--- a/src/server/verification/api/__tests__/__util__/index.js
+++ b/src/server/verification/api/__tests__/__util__/index.js
@@ -72,7 +72,6 @@ export default zoomServiceMock => {
         ok: false,
         code: 400,
         mode: 'dev',
-        subCode: 'unableToProcess',
         message: '3D FaceMaps that are used with Search APIs must have had Liveness Proven.'
       }
     })
@@ -155,8 +154,7 @@ export default zoomServiceMock => {
         ok: false,
         code: 400,
         mode: 'dev',
-        message: enrollmentNotFoundMessage,
-        subCode: 'facemapNotFound'
+        message: enrollmentNotFoundMessage
       }
     })
 

--- a/src/server/verification/api/__tests__/__util__/index.js
+++ b/src/server/verification/api/__tests__/__util__/index.js
@@ -73,6 +73,13 @@ export default zoomServiceMock => {
         code: 400,
         mode: 'dev',
         message: '3D FaceMaps that are used with Search APIs must have had Liveness Proven.'
+      },
+      data: {
+        glasses: false,
+        sessionTokenStatus: 1,
+        faceMapType: 0,
+        livenessStatus: 1,
+        isLowQuality: false
       }
     })
 

--- a/src/server/verification/processor/provider/ZoomProvider.js
+++ b/src/server/verification/processor/provider/ZoomProvider.js
@@ -68,7 +68,7 @@ class ZoomProvider implements IEnrollmentProvider {
       const { subCode, message } = exception.response || {}
 
       // if liveness issues were detected
-      if ('unableToProcess' === subCode && message.toLowerCase().includes('liveness')) {
+      if ('livenessCheckFailed' === subCode) {
         const isLive = false
 
         // notifying about liveness check failed

--- a/src/server/verification/processor/provider/ZoomProvider.js
+++ b/src/server/verification/processor/provider/ZoomProvider.js
@@ -122,7 +122,7 @@ class ZoomProvider implements IEnrollmentProvider {
       // (e.g. liveness wasn't passsed, glasses detected, poor quality)
       if ('nameCollision' !== response.subCode) {
         const isEnrolled = false
-        const isLive = api.checkLivenessStatus(response)
+        const isLive = api.isLivenessCheckPassed(response)
 
         // then notifying & throwing enrollment exception
         await notifyProcessor({ isEnrolled, isLive })

--- a/src/server/verification/processor/provider/__tests__/ZoomProvider.js
+++ b/src/server/verification/processor/provider/__tests__/ZoomProvider.js
@@ -90,7 +90,7 @@ describe('ZoomProvider', () => {
       }
     })
 
-    zoomServiceMock.onPost('/enrollment').reply(200, {
+    zoomServiceMock.onPost('/enrollment').reply(400, {
       meta: {
         ok: false,
         code: 400,

--- a/src/server/verification/processor/provider/__tests__/ZoomProvider.js
+++ b/src/server/verification/processor/provider/__tests__/ZoomProvider.js
@@ -95,8 +95,7 @@ describe('ZoomProvider', () => {
         ok: false,
         code: 400,
         mode: 'dev',
-        message: 'An enrollment already exists for this enrollmentIdentifier.',
-        subCode: 'nameCollision'
+        message: 'An enrollment already exists for this enrollmentIdentifier.'
       }
     })
 


### PR DESCRIPTION
# Description

Subcodes aren't passed on dedicated server / production mode
this breaks all FV logic if the face was already enrolled

Also we have a few more places where subCode is used.
In all this cases we should analyze the message field to determine the kind of exception

About #230 


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
