### PR TITLE
(Bug) Express deprecated syntax crashes logs

### DIFF
--- a/src/imports/logger.js
+++ b/src/imports/logger.js
@@ -1,40 +1,19 @@
 // libraries
 import winston from 'winston'
-import errorSerializer from 'pino-std-serializers/lib/err'
-import { omit, isPlainObject, isError } from 'lodash'
+import { omit, isPlainObject, mapValues } from 'lodash'
 import Crypto from 'crypto'
-import { SPLAT } from 'triple-beam'
 
 // configs
 import ErrorsTransport from './logger/ErrorsTransport'
 import conf from '../server/server.config'
 
-const { format } = winston
-const { combine, printf, timestamp } = format
-const colorizer = format.colorize()
+import { levelConfigs } from './logger/options'
+import { extended } from './logger/formatter'
 
+const { combine, timestamp, errors } = winston.format
 const { env, logLevel } = conf
 
 console.log('Starting logger', { logLevel, env })
-
-const levelConfigs = {
-  levels: {
-    error: 0,
-    warn: 1,
-    info: 2,
-    http: 3,
-    debug: 4,
-    trace: 5
-  },
-  colors: {
-    error: 'red',
-    warn: 'yellow',
-    info: 'cyan',
-    debug: 'green',
-    trace: 'white',
-    http: 'bold green'
-  }
-}
 
 const transports = [
   new winston.transports.Console({
@@ -47,50 +26,10 @@ const logger = winston.createLogger({
   transports,
   level: logLevel,
   levels: levelConfigs.levels,
-  format: combine(
-    timestamp(),
-    format.errors({ stack: true }),
-    printf(({ level, timestamp, from, userId, message, ...rest }) => {
-      const logPayload = { message, context: rest[SPLAT] }
-      const stringifiedPayload = JSON.stringify(logPayload, (_, value) =>
-        isError(value) ? errorSerializer(value) : value
-      )
-      return colorizer.colorize(
-        level,
-        `${timestamp} - workerId:${global.workerId} - ${level}${
-          from ? ` (FROM ${from} ${userId || ''})` : ''
-        }: ${stringifiedPayload}`
-      )
-    })
-  )
+  format: combine(timestamp(), errors({ stack: true }), extended())
 })
 
 winston.addColors(levelConfigs.colors)
-
-Object.defineProperty(logger.constructor.prototype, 'async', {
-  get() {
-    let { _asyncProxy } = this
-
-    if (!_asyncProxy) {
-      const _transports = transports.filter(({ silent }) => true !== silent)
-
-      _asyncProxy = new Proxy(this, {
-        get: (target, method) => async (...args) => {
-          const promise = Promise.all(
-            _transports.map(transport => new Promise(resolve => transport.once('logged', resolve)))
-          )
-
-          target[method](...args)
-          return promise
-        }
-      })
-
-      this._asyncProxy = _asyncProxy
-    }
-
-    return _asyncProxy
-  }
-})
 
 /**
  * Sets log middleware
@@ -126,12 +65,12 @@ export const addRequestLogger = (req, res, next) => {
 // print memory fn
 const printMemory = () => {
   const used = process.memoryUsage()
-  let toPrint = {}
-  for (let key in used) {
-    toPrint[key] = `${Math.round((used[key] / 1024 / 1024) * 100) / 100} MB`
-  }
-  logger.debug('Memory usage:', toPrint)
+
+  logger.debug('Memory usage:', mapValues(used, value => `${Math.round(value / (1 << 20), 2)} MB`))
 }
-if (env !== 'test') setInterval(printMemory, 30000)
+
+if ('test' !== env) {
+  setInterval(printMemory, 30000)
+}
 
 export default logger

--- a/src/imports/logger.js
+++ b/src/imports/logger.js
@@ -62,6 +62,13 @@ export const addRequestLogger = (req, res, next) => {
   next()
 }
 
+// add logging of the deprecation errors
+process.on('deprecation', exception => {
+  const { message } = exception
+
+  logger.error('Deprecation error:', message, exception)
+})
+
 // print memory fn
 const printMemory = () => {
   const used = process.memoryUsage()

--- a/src/imports/logger/formatter.js
+++ b/src/imports/logger/formatter.js
@@ -1,0 +1,23 @@
+// @flow
+
+import winston from 'winston'
+import errorSerializer from 'pino-std-serializers/lib/err'
+import { isError } from 'lodash'
+import { SPLAT } from 'triple-beam'
+
+const { printf, colorize } = winston.format
+const colorizer = colorize()
+
+export const extended = () =>
+  printf(({ level, timestamp, from, userId, message, ...rest }) => {
+    const logPayload = { message, context: rest[SPLAT] }
+    const fromString = from ? ` (FROM ${from} ${userId || ''})` : ''
+
+    const stringifiedPayload = JSON.stringify(logPayload, (_, value) =>
+      isError(value) ? errorSerializer(value) : value
+    )
+
+    const logMessage = `${timestamp} - workerId:${global.workerId} - ${level}${fromString}: ${stringifiedPayload}`
+
+    return colorizer.colorize(level, logMessage)
+  })

--- a/src/imports/logger/middleware.js
+++ b/src/imports/logger/middleware.js
@@ -1,0 +1,34 @@
+// @flow
+import { omit, isPlainObject } from 'lodash'
+import Crypto from 'crypto'
+
+export const createLoggerMiddleware = logger => (req, res, next) => {
+  const startTime = Date.now()
+  let uuid = Math.random() + ' ' + startTime
+
+  uuid = Crypto.createHash('sha1')
+    .update(uuid)
+    .digest('base64')
+    .slice(0, 10)
+
+  req.log = logger.child({ uuid, from: req.url, userId: req.user && req.user.identifier })
+
+  res.on('finish', () => {
+    const responseTimeSeconds = (Date.now() - startTime) / 1000
+    let logBody = req.body
+
+    if (req.url.startsWith('/verify/face/') && isPlainObject(logBody)) {
+      logBody = omit(logBody, 'faceMap', 'auditTrailImage', 'lowQualityAuditTrailImage')
+    }
+
+    req.log.log('http', 'Incoming Request', {
+      responseTimeSeconds,
+      method: req.method,
+      body: logBody,
+      query: req.query,
+      headers: req.headers
+    })
+  })
+
+  next()
+}

--- a/src/imports/logger/monitor.js
+++ b/src/imports/logger/monitor.js
@@ -1,0 +1,48 @@
+import { isError, isString, assign } from 'lodash'
+
+export const addLoggerMonitor = logger => {
+  const log = logger.child({ from: 'GoodServer' })
+
+  // add logging of deprecation errors
+  process.on('deprecation', deprecationError => {
+    const { message } = deprecationError
+
+    log.warn('Deprecation error:', message, deprecationError)
+  })
+
+  // add logging of warnings
+  process.on('warning', warning => {
+    const { message } = warning
+
+    log.warn('Warning:', message, warning)
+  })
+
+  // add logging of uncaught exceptions
+  process.on('uncaughtExceptionMonitor', (exception, origin) => {
+    const { message } = exception
+
+    log.error('Uncaught exception at:', message, exception, { origin })
+  })
+
+  // add logging of unhandled promise rejections
+  process.on('unhandledRejection', reason => {
+    let message = ''
+    let logPayload = {}
+    let exception = reason
+    const label = 'Unhandled promise rejection'
+
+    if (isError(reason)) {
+      message = reason.message
+    } else {
+      if (isString(reason)) {
+        message = reason
+      } else {
+        logPayload = { reason }
+      }
+
+      exception = new Error(message || label)
+    }
+
+    log.error(`${label} at:`, message, exception, logPayload)
+  })
+}

--- a/src/imports/logger/monitor.js
+++ b/src/imports/logger/monitor.js
@@ -1,4 +1,4 @@
-import { isError, isString, assign } from 'lodash'
+import { isError, isString } from 'lodash'
 
 export const addLoggerMonitor = logger => {
   const log = logger.child({ from: 'GoodServer' })

--- a/src/imports/logger/options.js
+++ b/src/imports/logger/options.js
@@ -1,0 +1,20 @@
+// @flow
+
+export const levelConfigs = {
+  levels: {
+    error: 0,
+    warn: 1,
+    info: 2,
+    http: 3,
+    debug: 4,
+    trace: 5
+  },
+  colors: {
+    error: 'red',
+    warn: 'yellow',
+    info: 'cyan',
+    debug: 'green',
+    trace: 'white',
+    http: 'bold green'
+  }
+}

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,22 +1,13 @@
 import express from 'express'
+
 import middlewares from './server-middlewares'
 import { EventEmitter } from 'events'
 
 EventEmitter.defaultMaxListeners = 100
+// we're logging uncaught exceptions in logger monitor so just exiting process
+process.on('uncaughtException', () => process.exit(-1))
 
 const startApp = () => {
-  if (process.env.NODE_ENV !== 'test') {
-    process.on('uncaughtException', (err, origin) => {
-      console.log(`Uncaught exception: ${err}\nException origin: ${origin}`)
-      process.exit(-1)
-    })
-
-    process.on('unhandledRejection', (reason, promise) => {
-      console.log('Unhandled Rejection at:', promise, 'reason:', reason)
-      // Application specific logging, throwing an error, or other logic here
-    })
-  }
-
   const app = express()
 
   app.use(express.static('public'))

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -5,6 +5,18 @@ import { EventEmitter } from 'events'
 EventEmitter.defaultMaxListeners = 100
 
 const startApp = () => {
+  if (process.env.NODE_ENV !== 'test') {
+    process.on('uncaughtException', (err, origin) => {
+      console.log(`Uncaught exception: ${err}\nException origin: ${origin}`)
+      process.exit(-1)
+    })
+
+    process.on('unhandledRejection', (reason, promise) => {
+      console.log('Unhandled Rejection at:', promise, 'reason:', reason)
+      // Application specific logging, throwing an error, or other logic here
+    })
+  }
+
   const app = express()
 
   app.use(express.static('public'))

--- a/src/server/blockchain/__tests__/stakingModelManager.test.js
+++ b/src/server/blockchain/__tests__/stakingModelManager.test.js
@@ -80,7 +80,6 @@ describe('stakingModelManager', () => {
 
   test(`stakingModelManager should return next cronTime`, async () => {
     const { cronTime } = await fundManager.run().catch(_ => _)
-    console.log({ cronTime })
     expect(cronTime.isAfter()).toBeTruthy()
   })
 })

--- a/src/server/server-dev.js
+++ b/src/server/server-dev.js
@@ -3,46 +3,18 @@ import webpack from 'webpack'
 import webpackHotMiddleware from 'webpack-hot-middleware'
 import config from '../../webpack.dev.config'
 import conf from './server.config'
-import { GunDBPublic } from './gun/gun-middleware'
 import startApp from './app'
-import AdminWallet from './blockchain/AdminWallet'
-
-process.on('uncaughtException', (err, origin) => {
-  console.log(`Caught exception: ${err}\nException origin: ${origin}`)
-  console.log(err.stack)
-  process.exit(-1)
-})
-process.on('unhandledRejection', (reason, promise) => {
-  console.log('Unhandled Rejection at:', promise, 'reason:', reason)
-  // Application specific logging, throwing an error, or other logic here
-})
 
 const compiler = webpack(config)
-// app.use(webpackDevMiddleware(compiler, {
-//   publicPath: config.output.publicPath
-// }))
 const app = startApp()
 
 app.use(webpackHotMiddleware(compiler))
 
-// const DIST_DIR = __dirname
-// const HTML_FILE = path.join(DIST_DIR, 'index.html')
-// app.get("*", (req, res, next) => {
-//   compiler.outputFileSystem.readFile(HTML_FILE, (err, result) => {
-//     if (err) {
-//       return next(err)
-//     }
-//     res.set("content-type", "text/html")
-//     res.send(result)
-//     res.end()
-//     return false
-//   })
-// })
-
 console.log({ conf })
+
 const PORT = conf.port || 8080
 
-const server = app.listen(PORT, () => {
+app.listen(PORT, () => {
   console.log(`App listening to ${PORT}....`)
   console.log('Press Ctrl+C to quit.')
 })

--- a/src/server/server-prod.js
+++ b/src/server/server-prod.js
@@ -6,19 +6,11 @@ export default function start(workerId) {
   global.workerId = workerId
   console.log(`start workerId = ${workerId}`)
 
-  process.on('uncaughtException', (err, origin) => {
-    console.log(`Uncaught exception: ${err}\nException origin: ${origin}`)
-    process.exit(-1)
-  })
-  process.on('unhandledRejection', (reason, promise) => {
-    console.log('Unhandled Rejection at:', promise, 'reason:', reason)
-    // Application specific logging, throwing an error, or other logic here
-  })
-
   const DIST_DIR = __dirname
 
   const HTML_FILE = path.join(DIST_DIR, 'index.html')
   const app = startApp()
+
   app.use(express.static(DIST_DIR))
 
   app.get('*', (req, res) => {
@@ -26,7 +18,8 @@ export default function start(workerId) {
   })
 
   const PORT = process.env.PORT || 3000
-  const server = app.listen(PORT, () => {
+
+  app.listen(PORT, () => {
     console.log(`App listening to ${PORT}....`)
     console.log('Press Ctrl+C to quit.')
   })

--- a/src/server/verification/processor/EnrollmentSession.js
+++ b/src/server/verification/processor/EnrollmentSession.js
@@ -55,8 +55,8 @@ export default class EnrollmentSession {
         result.enrollmentResult = response
       }
 
-      await log.async.error('Enrollment session failed with exception:', message, exception, { result })
       this.onEnrollmentFailed(exception)
+      log.error('Enrollment session failed with exception:', message, exception, { result })
     } finally {
       this.sessionRef = null
     }


### PR DESCRIPTION
# Description

- ErrorTransport has been rewritten using official example as the base
- removed async stuff from loggin as it's not correctly supported by the winston
- adjusted the code in the places where some error.message is used. We're copying it to some var / calling function requires message to be passed and only then logging the error
- added process.on('deprecation') event listener, logging deprecations as errors via logger to avoid conflicts between winston and depd

About #231


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
