### PR TITLE
(Bug) FV liveness failure should show the zoom native "retry" screen

### DIFF
--- a/src/server/verification/processor/provider/ZoomProvider.js
+++ b/src/server/verification/processor/provider/ZoomProvider.js
@@ -65,11 +65,12 @@ class ZoomProvider implements IEnrollmentProvider {
         ({ enrollmentIdentifier: matchId }) => matchId.toLowerCase() !== enrollmentIdentifier.toLowerCase()
       )
     } catch (exception) {
-      const { subCode, message } = exception.response || {}
+      faceSearchResponse = exception.response || {}
 
       // if liveness issues were detected
-      if ('livenessCheckFailed' === subCode) {
+      if ('livenessCheckFailed' === faceSearchResponse.subCode) {
         const isLive = false
+        const { message } = faceSearchResponse
 
         // notifying about liveness check failed
         await notifyProcessor({ isLive })


### PR DESCRIPTION
# Description

- fixed api response for the liveness failed during face search. The original ZoOm metadata (code, subCode, etc) was lost during previous changes. Restored

About https://github.com/GoodDollar/GoodDAPP/issues/2399


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
