### PR TITLE
(Chore) Server should use delete enrollment if it's supported by the particular V9 instance

### DIFF
--- a/src/server/verification/__tests__/verificationAPI.js
+++ b/src/server/verification/__tests__/verificationAPI.js
@@ -132,6 +132,9 @@ describe('verificationAPI', () => {
       await storage.taskModel.deleteMany({ subject: enrollmentIdentifier })
 
       enrollmentProcessor.keepEnrollments = 24
+      delete enrollmentProcessor.provider._apiFeatures
+      helper.mockServerRunning()
+
       isVerifiedMock.mockResolvedValue(false)
     })
 

--- a/src/server/verification/api/ZoomAPI.js
+++ b/src/server/verification/api/ZoomAPI.js
@@ -45,6 +45,12 @@ class ZoomAPI {
     this._configureResponses()
   }
 
+  async getAPIFeatures(customLogger = null) {
+    const response = await this.http.get('/status', { customLogger })
+
+    return get(response, 'extra', [])
+  }
+
   async getSessionToken(customLogger = null) {
     const response = await this.http.get('/session-token', { customLogger })
 
@@ -56,12 +62,6 @@ class ZoomAPI {
     }
 
     return response
-  }
-
-  async getAPIFeatures(customLogger = null) {
-    const response = await this.http.get('/status', { customLogger })
-
-    return get(response, 'extra', [])
   }
 
   // eslint-disable-next-line require-await

--- a/src/server/verification/api/ZoomAPI.js
+++ b/src/server/verification/api/ZoomAPI.js
@@ -14,6 +14,11 @@ export const ZoomAPIError = {
   NameCollision: 'nameCollision'
 }
 
+export const ZoomAPIFeature = {
+  DisposeEnrollment: 'delete-enrollment-3d',
+  ImportLegacyFacemaps: 'import-v8-facemap'
+}
+
 export const failedEnrollmentMessage = 'FaceMap could not be enrolled'
 export const failedLivenessMessage = 'Liveness could not be determined'
 export const enrollmentNotFoundMessage = 'An enrollment does not exists for this enrollment identifier'
@@ -53,28 +58,20 @@ class ZoomAPI {
     return response
   }
 
+  async getAPIFeatures(customLogger = null) {
+    const response = await this.http.get('/status', { customLogger })
+
+    return get(response, 'extra', [])
+  }
+
+  // eslint-disable-next-line require-await
   async readEnrollment(enrollmentIdentifier, customLogger = null) {
-    let response
+    return this._enrollmentRequest('get', enrollmentIdentifier, customLogger)
+  }
 
-    try {
-      response = await this.http.get('/enrollment-3d/:enrollmentIdentifier', {
-        customLogger,
-        params: { enrollmentIdentifier }
-      })
-    } catch (exception) {
-      const { message } = exception
-
-      if (/no\s+entry\s+found/i.test(message)) {
-        assign(exception, {
-          name: ZoomAPIError.FacemapNotFound,
-          message: enrollmentNotFoundMessage
-        })
-      }
-
-      throw exception
-    }
-
-    return response
+  // eslint-disable-next-line require-await
+  async disposeEnrollment(enrollmentIdentifier, customLogger = null) {
+    return this._enrollmentRequest('delete', enrollmentIdentifier, customLogger)
   }
 
   async checkLiveness(payload, customLogger = null) {
@@ -311,6 +308,30 @@ class ZoomAPI {
     }
 
     return databaseIndex
+  }
+
+  async _enrollmentRequest(operation, enrollmentIdentifier, customLogger = null) {
+    let response
+
+    try {
+      response = await this.http[operation]('/enrollment-3d/:enrollmentIdentifier', {
+        customLogger,
+        params: { enrollmentIdentifier }
+      })
+    } catch (exception) {
+      const { message } = exception
+
+      if (/(no\s+entry\s+found|no\s+records\s+were)/i.test(message)) {
+        assign(exception, {
+          name: ZoomAPIError.FacemapNotFound,
+          message: enrollmentNotFoundMessage
+        })
+      }
+
+      throw exception
+    }
+
+    return response
   }
 
   async _faceScanRequest(operation, payload, additionalData = null, customLogger = null) {

--- a/src/server/verification/processor/__tests__/EnrollmentProcessor.js
+++ b/src/server/verification/processor/__tests__/EnrollmentProcessor.js
@@ -63,7 +63,6 @@ const testValidation = async (validationPromise, errorMessage = 'Invalid input')
 
 describe('EnrollmentProcessor', () => {
   const enrollmentProcessor = createEnrollmentProcessor(storageMock)
-  const { keepEnrollments } = enrollmentProcessor
 
   beforeAll(() => {
     AdminWallet.whitelistUser = whitelistUserMock
@@ -76,11 +75,12 @@ describe('EnrollmentProcessor', () => {
   })
 
   beforeEach(() => {
-    enrollmentProcessor.keepEnrollments = 24
-
     isVerifiedMock.mockResolvedValue(false)
     hasTasksQueuedMock.mockReturnValue(false)
     enqueueTaskMock.mockResolvedValue({ _id: 'fake-task-id' })
+
+    delete enrollmentProcessor.provider._apiFeatures
+    helper.mockServerRunning()
 
     invokeMap(
       [
@@ -125,7 +125,6 @@ describe('EnrollmentProcessor', () => {
     ClaimQueue.whitelistUser = setWhitelistedImplementation
     restoreWalletMethods.forEach(method => (AdminWallet[method] = AdminWallet.constructor.prototype[method]))
 
-    assign(enrollmentProcessor, { keepEnrollments })
     zoomServiceMock.restore()
     zoomServiceMock = null
     helper = null

--- a/src/server/verification/processor/provider/ZoomProvider.js
+++ b/src/server/verification/processor/provider/ZoomProvider.js
@@ -105,6 +105,8 @@ class ZoomProvider implements IEnrollmentProvider {
           await this.dispose(enrollmentIdentifier)
           // then enrolling it with the new data already verified for liveness
           await enroll()
+          // setting enrolled flag to false as we re-enrolled the facemap
+          alreadyEnrolled = false
         }
       } else {
         // if not enrolled/stored yet - just calling enroll.

--- a/src/server/verification/processor/provider/ZoomProvider.js
+++ b/src/server/verification/processor/provider/ZoomProvider.js
@@ -1,5 +1,5 @@
 // @flow
-import { omit, once, omitBy } from 'lodash'
+import { omit, once, omitBy, assign } from 'lodash'
 
 import initZoomAPI, { faceSnapshotFields, ZoomAPIError } from '../../api/ZoomAPI.js'
 import logger from '../../../../imports/logger'
@@ -13,6 +13,7 @@ export const alreadyEnrolledMessage = 'The FaceMap was already enrolled.'
 class ZoomProvider implements IEnrollmentProvider {
   api = null
   logger = null
+  _apiFeatures = null
 
   constructor(api, logger) {
     this.api = api
@@ -208,6 +209,17 @@ class ZoomProvider implements IEnrollmentProvider {
       log.warn('Error disposing enrollment', { e: exception, errMessage, enrollmentIdentifier })
       throw exception
     }
+  }
+
+  async _supportsFeature(feature: string): Promise<boolean> {
+    let { _apiFeatures, api } = this
+
+    if (!_apiFeatures) {
+      _apiFeatures = await api.getAPIFeatures()
+      assign(this, { _apiFeatures })
+    }
+
+    return _apiFeatures.includes(feature)
   }
 
   _isNotIndexedException(enrollmentIdentifier, exception, customLogger) {


### PR DESCRIPTION
# Description

- added API method for read server features
- restored API method for  delete enrollment
- added method to check is delete supported to the provider
- if delete is supported, dispose will also delete the facemap itself (not only from the index)
- if delete is supported, enroll will re-upload facemap to the database (firslty call liveness check to make sure enroll will be successfull, then delete enrollment and enroll it again)

About #280 

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [x] @mentions of the person or team responsible for reviewing proposed changes
