### PR TITLE
refactor: remove incorrect address assignment in Web3Wallet initialization

### DIFF
--- a/src/server/blockchain/Web3Wallet.js
+++ b/src/server/blockchain/Web3Wallet.js
@@ -390,6 +390,26 @@ export class Web3Wallet {
 
       log.info('Initializing adminwallet addresses', { addresses: this.addresses })
 
+      for (const addr of this.addresses) {
+        const balance = await this.web3.eth.getBalance(addr)
+        const isAdminWallet = await this.isVerifiedAdmin(addr)
+
+        if (isAdminWallet && parseFloat(web3Utils.fromWei(balance, 'gwei')) > minAdminBalance) {
+          log.info(`WalletInit: set default wallet to ${addr} with balance ${balance}`)
+          this.address = addr
+          break
+        }
+      }
+      // this.address = this.filledAddresses[0]
+      this.proxyContract = new this.web3.eth.Contract(AdminWalletABI, adminWalletAddress, { from: this.address })
+
+      if (this.conf.topAdminsOnStartup) {
+        log.info('WalletInit: calling topAdmins...')
+        await this.topAdmins(this.conf.numberOfAdminWalletAccounts).catch(e => {
+          log.warn('WalletInit: topAdmins failed', { e, errMessage: e.message })
+        })
+      }
+
       await Promise.all(
         this.addresses.map(async addr => {
           const balance = await this.web3.eth.getBalance(addr)
@@ -411,16 +431,6 @@ export class Web3Wallet {
 
         await sendSlackAlert({
           msg: `critical: no fuse admin wallet with funds ${this.name}`
-        })
-      }
-
-      this.address = this.filledAddresses[0]
-      this.proxyContract = new this.web3.eth.Contract(AdminWalletABI, adminWalletAddress, { from: this.address })
-
-      if (this.conf.topAdminsOnStartup) {
-        log.info('WalletInit: calling topAdmins...')
-        await this.topAdmins(this.conf.numberOfAdminWalletAccounts).catch(e => {
-          log.warn('WalletInit: topAdmins failed', { e, errMessage: e.message })
         })
       }
 

--- a/src/server/blockchain/Web3Wallet.js
+++ b/src/server/blockchain/Web3Wallet.js
@@ -368,7 +368,8 @@ export class Web3Wallet {
       const adminWalletContractBalance = await this.web3.eth.getBalance(adminWalletAddress)
       log.info(`WalletInit: AdminWallet contract balance`, { adminWalletContractBalance, adminWalletAddress })
 
-      this.proxyContract = new this.web3.eth.Contract(AdminWalletABI, adminWalletAddress, { from: this.address })
+      // Initialize without `from` first, then re-bind after selecting a valid admin wallet.
+      this.proxyContract = new this.web3.eth.Contract(AdminWalletABI, adminWalletAddress)
 
       const maxAdminBalance = await this.proxyContract.methods.adminToppingAmount().call()
       const minAdminBalance = parseInt(web3Utils.fromWei(maxAdminBalance, 'gwei')) / 2
@@ -386,13 +387,6 @@ export class Web3Wallet {
       await this.txManager.createListIfNotExists(this.addresses)
 
       log.info('WalletInit: Initialized wallet queue manager')
-
-      if (this.conf.topAdminsOnStartup) {
-        log.info('WalletInit: calling topAdmins...')
-        await this.topAdmins(this.conf.numberOfAdminWalletAccounts).catch(e => {
-          log.warn('WalletInit: topAdmins failed', { e, errMessage: e.message })
-        })
-      }
 
       log.info('Initializing adminwallet addresses', { addresses: this.addresses })
 
@@ -421,6 +415,14 @@ export class Web3Wallet {
       }
 
       this.address = this.filledAddresses[0]
+      this.proxyContract = new this.web3.eth.Contract(AdminWalletABI, adminWalletAddress, { from: this.address })
+
+      if (this.conf.topAdminsOnStartup) {
+        log.info('WalletInit: calling topAdmins...')
+        await this.topAdmins(this.conf.numberOfAdminWalletAccounts).catch(e => {
+          log.warn('WalletInit: topAdmins failed', { e, errMessage: e.message })
+        })
+      }
 
       this.identityContract = new this.web3.eth.Contract(
         IdentityABI.abi,

--- a/src/server/blockchain/Web3Wallet.js
+++ b/src/server/blockchain/Web3Wallet.js
@@ -316,7 +316,6 @@ export class Web3Wallet {
         const keyId = this.kmsWallet.getKeyId(address)
         this.addKMSWallet(address, keyId)
       })
-      this.address = addresses[0]
       log.info('WalletInit: Initialized by KMS keys:', {
         addresses,
         keyIds: kmsKeyIds,
@@ -339,8 +338,6 @@ export class Web3Wallet {
 
           this.addWallet(account)
         }
-
-        this.address = this.addresses[0]
 
         log.info('WalletInit: Initialized by mnemonic:', { address: this.addresses })
       } else if (this.conf.privateKey) {


### PR DESCRIPTION
# Description

Remove incorrect default address assignment in web3Wallet initialization

About # (link your issue here)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes

## Summary by Sourcery

Bug Fixes:
- Prevent Web3Wallet from automatically assigning its primary address to the first derived or KMS-provided address during initialization, avoiding incorrect address state.